### PR TITLE
Fix calc(var(-- something))

### DIFF
--- a/min.css.js
+++ b/min.css.js
@@ -110,7 +110,7 @@ function mincss (css) {
     return r;
   })
   .replace(/\:\s*calc\(([^;}]+)/g, function ($0) { // Repair CSS3 calc conditions
-    return $0.replace(/\s+/g, "").replace(/([-+*/]+)/g, " $1 ");
+    return $0.replace(/\s+/g, "").replace(/([-+*/]+)/g, " $1 ").replace(/(--)\s/g, "$1");
   })
   ;
 }


### PR DESCRIPTION
Fix problem with extra whitespace before css variables inside calc()